### PR TITLE
crusher: external hip prefix should be /opt/rocm-5.2.0

### DIFF
--- a/crusher/packages.yaml
+++ b/crusher/packages.yaml
@@ -163,7 +163,7 @@ packages:
     buildable: false
     externals:
     - spec: hip@5.2.0
-      prefix: /opt/rocm-5.2.0/hip
+      prefix: /opt/rocm-5.2.0
       modules:
       - craype-accel-amd-gfx90a
       - rocm/5.2.0


### PR DESCRIPTION
I have had to make this change to get some packages to build. I think it has to do with how the hipcc script determines paths, and it being dependent on whether the script is invoked /opt/rocm-5.2.0/hip/bin/hipcc vs /opt/rocm-5.2.0/bin/hipcc, even though the former is a symlink to the latter... I'm not sure though. 

Do you have thoughts @kwryankrattiger ?