### PR TITLE
crusher: add hipsolver external

### DIFF
--- a/crusher/packages.yaml
+++ b/crusher/packages.yaml
@@ -225,6 +225,12 @@ packages:
       prefix: /opt/rocm-5.2.0
       modules:
       - rocm/5.2.0
+  hipsolver:
+    buildable: false
+    externals:
+    - spec: hipsolver@5.2.0
+      prefix: /opt/rocm-5.2.0
+      modules: [rocm/5.2.0]    
   rocsolver:
     buildable: false
     externals:


### PR DESCRIPTION
Used this external definition of `hipsolver@5.2.0` to successfully install a few `hipsolver`-dependent packages on Crusher. @kwryankrattiger @wspear