### PR TITLE
Frontier configs

### DIFF
--- a/frontier/compilers.yaml
+++ b/frontier/compilers.yaml
@@ -133,7 +133,7 @@ compilers:
       fc: /usr/bin/gfortran
     flags: {}
     operating_system: sles15
-    modules: {}
+    modules: []
     environment:
       append_path:
         PKG_CONFIG_PATH: /usr/lib64/pkgconfig

--- a/frontier/compilers.yaml
+++ b/frontier/compilers.yaml
@@ -18,8 +18,9 @@ compilers:
       set:
         RFE_811452_DISABLE: '1'
       append_path:
-        PKG_CONFIG_PATH: /opt/cray/xpmem/2.5.2-2.4_3.30__gd0f7936.shasta/lib64/pkgconfig:/usr/lib64/pkgconfig
+        PKG_CONFIG_PATH: /opt/cray/xpmem/2.5.2-2.4_3.45__gd0f7936.shasta/lib64/pkgconfig:/usr/lib64/pkgconfig
         LD_LIBRARY_PATH: /opt/cray/pe/gcc-libs:/opt/cray/libfabric/1.15.2.0/lib64
+        LD_PRELOAD: /opt/cray/pe/libsci/22.12.1.1/CRAY/9.0/x86_64/lib/libsci_cray_mp.so.5
       prepend_path:
         LD_LIBRARY_PATH: /opt/cray/pe/pmi/6.1.8/lib
         LIBRARY_PATH: /opt/rocm-5.4.3/lib:/opt/rocm-5.4.3/lib64
@@ -47,7 +48,7 @@ compilers:
       set:
         RFE_811452_DISABLE: '1'
       append_path:
-        PKG_CONFIG_PATH: /opt/cray/xpmem/2.5.2-2.4_3.30__gd0f7936.shasta/lib64/pkgconfig:/usr/lib64/pkgconfig
+        PKG_CONFIG_PATH: /opt/cray/xpmem/2.5.2-2.4_3.45__gd0f7936.shasta/lib64/pkgconfig:/usr/lib64/pkgconfig
         LD_LIBRARY_PATH: /opt/cray/pe/gcc-libs:/opt/cray/libfabric/1.15.2.0/lib64
       prepend_path:
         LD_LIBRARY_PATH: /opt/cray/pe/pmi/6.1.8/lib
@@ -78,10 +79,10 @@ compilers:
         RFE_811452_DISABLE: '1'
         HIPCC: CC
       append_path:
-        PKG_CONFIG_PATH: /opt/cray/xpmem/2.5.2-2.4_3.30__gd0f7936.shasta/lib64/pkgconfig:/usr/lib64/pkgconfig
-        LD_LIBRARY_PATH: /opt/cray/pe/gcc-libs:/opt/cray/libfabric/1.15.0.0/lib64
+        PKG_CONFIG_PATH: /opt/cray/xpmem/2.5.2-2.4_3.45__gd0f7936.shasta/lib64/pkgconfig:/usr/lib64/pkgconfig
+        LD_LIBRARY_PATH: /opt/cray/pe/gcc-libs:/opt/cray/libfabric/1.15.2.0/lib64
       prepend_path:
-        LD_LIBRARY_PATH: /opt/cray/pe/pmi/6.1.3/lib
+        LD_LIBRARY_PATH: /opt/cray/pe/pmi/6.1.8/lib
     extra_rpaths:
     - /opt/cray/pe/gcc-libs
     - /opt/cray/gcc-libs
@@ -106,10 +107,10 @@ compilers:
         RFE_811452_DISABLE: '1'
         HIPCC: CC
       append_path:
-        PKG_CONFIG_PATH: /opt/cray/xpmem/2.5.2-2.4_3.30__gd0f7936.shasta/lib64/pkgconfig:/usr/lib64/pkgconfig
-        LD_LIBRARY_PATH: /opt/cray/pe/gcc-libs:/opt/cray/libfabric/1.15.0.0/lib64
+        PKG_CONFIG_PATH: /opt/cray/xpmem/2.5.2-2.4_3.45__gd0f7936.shasta/lib64/pkgconfig:/usr/lib64/pkgconfig
+        LD_LIBRARY_PATH: /opt/cray/pe/gcc-libs:/opt/cray/libfabric/1.15.2.0/lib64
       prepend_path:
-        LD_LIBRARY_PATH: /opt/cray/pe/pmi/6.1.3/lib
+        LD_LIBRARY_PATH: /opt/cray/pe/pmi/6.1.8/lib
     extra_rpaths:
     - /opt/cray/pe/gcc-libs
     - /opt/cray/gcc-libs
@@ -131,7 +132,7 @@ compilers:
     - cray-pmi/6.1.8
     environment:
       append_path:
-        PKG_CONFIG_PATH: /opt/cray/xpmem/2.5.2-2.4_3.30__gd0f7936.shasta/lib64/pkgconfig:/usr/lib64/pkgconfig
+        PKG_CONFIG_PATH: /opt/cray/xpmem/2.5.2-2.4_3.45__gd0f7936.shasta/lib64/pkgconfig:/usr/lib64/pkgconfig
     extra_rpaths: []
 - compiler:
     spec: gcc@12.2.0
@@ -151,5 +152,5 @@ compilers:
     - cray-pmi/6.1.8
     environment:
       append_path:
-        PKG_CONFIG_PATH: /opt/cray/xpmem/2.5.2-2.4_3.30__gd0f7936.shasta/lib64/pkgconfig:/usr/lib64/pkgconfig
+        PKG_CONFIG_PATH: /opt/cray/xpmem/2.5.2-2.4_3.45__gd0f7936.shasta/lib64/pkgconfig:/usr/lib64/pkgconfig
     extra_rpaths: []

--- a/frontier/compilers.yaml
+++ b/frontier/compilers.yaml
@@ -1,0 +1,155 @@
+compilers:
+- compiler:
+    spec: clang@15.0.0-rocm5.4.3
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    operating_system: sles15
+    modules:
+    - PrgEnv-amd
+    - amd/5.4.3
+    - xpmem
+    - craype-x86-trento
+    - libfabric
+    - cray-pmi/6.1.8
+    environment:
+      set:
+        RFE_811452_DISABLE: '1'
+      append_path:
+        PKG_CONFIG_PATH: /opt/cray/xpmem/2.5.2-2.4_3.30__gd0f7936.shasta/lib64/pkgconfig:/usr/lib64/pkgconfig
+        LD_LIBRARY_PATH: /opt/cray/pe/gcc-libs:/opt/cray/libfabric/1.15.2.0/lib64
+      prepend_path:
+        LD_LIBRARY_PATH: /opt/cray/pe/pmi/6.1.8/lib
+        LIBRARY_PATH: /opt/rocm-5.4.3/lib:/opt/rocm-5.4.3/lib64
+    extra_rpaths:
+    - /opt/rocm-5.4.3/lib
+    - /opt/rocm-5.4.3/lib64
+    - /opt/cray/pe/gcc-libs
+    - /opt/cray/gcc-libs
+- compiler:
+    spec: clang@14.0.0-rocm5.2.0
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    operating_system: sles15
+    modules:
+    - PrgEnv-amd
+    - amd/5.2.0
+    - xpmem
+    - craype-x86-trento
+    - libfabric
+    - cray-pmi/6.1.8
+    environment:
+      set:
+        RFE_811452_DISABLE: '1'
+      append_path:
+        PKG_CONFIG_PATH: /opt/cray/xpmem/2.5.2-2.4_3.30__gd0f7936.shasta/lib64/pkgconfig:/usr/lib64/pkgconfig
+        LD_LIBRARY_PATH: /opt/cray/pe/gcc-libs:/opt/cray/libfabric/1.15.2.0/lib64
+      prepend_path:
+        LD_LIBRARY_PATH: /opt/cray/pe/pmi/6.1.8/lib
+        LIBRARY_PATH: /opt/rocm-5.2.0/lib:/opt/rocm-5.2.0/lib64
+    extra_rpaths:
+    - /opt/rocm-5.2.0/lib
+    - /opt/rocm-5.2.0/lib64
+    - /opt/cray/pe/gcc-libs
+    - /opt/cray/gcc-libs
+- compiler:
+    spec: cce@14.0.2
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    flags: {}
+    operating_system: sles15
+    modules:
+    - PrgEnv-cray
+    - cce/14.0.2
+    - xpmem
+    - craype-x86-trento
+    - libfabric
+    - cray-pmi/6.1.8
+    environment:
+      set:
+        RFE_811452_DISABLE: '1'
+        HIPCC: CC
+      append_path:
+        PKG_CONFIG_PATH: /opt/cray/xpmem/2.5.2-2.4_3.30__gd0f7936.shasta/lib64/pkgconfig:/usr/lib64/pkgconfig
+        LD_LIBRARY_PATH: /opt/cray/pe/gcc-libs:/opt/cray/libfabric/1.15.0.0/lib64
+      prepend_path:
+        LD_LIBRARY_PATH: /opt/cray/pe/pmi/6.1.3/lib
+    extra_rpaths:
+    - /opt/cray/pe/gcc-libs
+    - /opt/cray/gcc-libs
+- compiler:
+    spec: cce@15.0.0
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    flags: {}
+    operating_system: sles15
+    modules:
+    - PrgEnv-cray
+    - cce/15.0.0
+    - xpmem
+    - craype-x86-trento
+    - libfabric
+    - cray-pmi/6.1.8
+    environment:
+      set:
+        RFE_811452_DISABLE: '1'
+        HIPCC: CC
+      append_path:
+        PKG_CONFIG_PATH: /opt/cray/xpmem/2.5.2-2.4_3.30__gd0f7936.shasta/lib64/pkgconfig:/usr/lib64/pkgconfig
+        LD_LIBRARY_PATH: /opt/cray/pe/gcc-libs:/opt/cray/libfabric/1.15.0.0/lib64
+      prepend_path:
+        LD_LIBRARY_PATH: /opt/cray/pe/pmi/6.1.3/lib
+    extra_rpaths:
+    - /opt/cray/pe/gcc-libs
+    - /opt/cray/gcc-libs
+- compiler:
+    spec: gcc@11.2.0
+    paths:
+      cc: gcc
+      cxx: g++
+      f77: gfortran
+      fc: gfortran
+    flags: {}
+    operating_system: sles15
+    modules:
+    - PrgEnv-gnu
+    - gcc/11.2.0
+    - xpmem
+    - craype-x86-trento
+    - libfabric
+    - cray-pmi/6.1.8
+    environment:
+      append_path:
+        PKG_CONFIG_PATH: /opt/cray/xpmem/2.5.2-2.4_3.30__gd0f7936.shasta/lib64/pkgconfig:/usr/lib64/pkgconfig
+    extra_rpaths: []
+- compiler:
+    spec: gcc@12.2.0
+    paths:
+      cc: gcc
+      cxx: g++
+      f77: gfortran
+      fc: gfortran
+    flags: {}
+    operating_system: sles15
+    modules:
+    - PrgEnv-gnu
+    - gcc/12.2.0
+    - xpmem
+    - craype-x86-trento
+    - libfabric
+    - cray-pmi/6.1.8
+    environment:
+      append_path:
+        PKG_CONFIG_PATH: /opt/cray/xpmem/2.5.2-2.4_3.30__gd0f7936.shasta/lib64/pkgconfig:/usr/lib64/pkgconfig
+    extra_rpaths: []

--- a/frontier/compilers.yaml
+++ b/frontier/compilers.yaml
@@ -57,7 +57,7 @@ compilers:
     - /opt/cray/pe/gcc-libs
     - /opt/cray/gcc-libs
 - compiler:
-    spec: cce@15.0.0a
+    spec: cce@15.0.0
     paths:
       cc: cc
       cxx: CC

--- a/frontier/compilers.yaml
+++ b/frontier/compilers.yaml
@@ -1,35 +1,5 @@
 compilers:
 - compiler:
-    spec: clang@15.0.0-rocm5.4.3
-    paths:
-      cc: cc
-      cxx: CC
-      f77: ftn
-      fc: ftn
-    operating_system: sles15
-    modules:
-    - PrgEnv-amd
-    - amd/5.4.3
-    - xpmem
-    - craype-x86-trento
-    - libfabric
-    - cray-pmi/6.1.8
-    environment:
-      set:
-        RFE_811452_DISABLE: '1'
-      append_path:
-        PKG_CONFIG_PATH: /opt/cray/xpmem/2.5.2-2.4_3.45__gd0f7936.shasta/lib64/pkgconfig:/usr/lib64/pkgconfig
-        LD_LIBRARY_PATH: /opt/cray/pe/gcc-libs:/opt/cray/libfabric/1.15.2.0/lib64
-        LD_PRELOAD: /opt/cray/pe/libsci/22.12.1.1/CRAY/9.0/x86_64/lib/libsci_cray_mp.so.5
-      prepend_path:
-        LD_LIBRARY_PATH: /opt/cray/pe/pmi/6.1.8/lib
-        LIBRARY_PATH: /opt/rocm-5.4.3/lib:/opt/rocm-5.4.3/lib64
-    extra_rpaths:
-    - /opt/rocm-5.4.3/lib
-    - /opt/rocm-5.4.3/lib64
-    - /opt/cray/pe/gcc-libs
-    - /opt/cray/gcc-libs
-- compiler:
     spec: clang@14.0.0-rocm5.2.0
     paths:
       cc: cc
@@ -87,7 +57,7 @@ compilers:
     - /opt/cray/pe/gcc-libs
     - /opt/cray/gcc-libs
 - compiler:
-    spec: cce@15.0.0
+    spec: cce@15.0.0a
     paths:
       cc: cc
       cxx: CC
@@ -153,4 +123,18 @@ compilers:
     environment:
       append_path:
         PKG_CONFIG_PATH: /opt/cray/xpmem/2.5.2-2.4_3.45__gd0f7936.shasta/lib64/pkgconfig:/usr/lib64/pkgconfig
+    extra_rpaths: []
+- compiler:
+    spec: gcc@7.5.0-system
+    paths:
+      cc: /usr/bin/gcc
+      cxx: /usr/bin/g++
+      f77: /usr/bin/gfortran
+      fc: /usr/bin/gfortran
+    flags: {}
+    operating_system: sles15
+    modules: {}
+    environment:
+      append_path:
+        PKG_CONFIG_PATH: /usr/lib64/pkgconfig
     extra_rpaths: []

--- a/frontier/cray-python/3.9.13.1/packages.yaml
+++ b/frontier/cray-python/3.9.13.1/packages.yaml
@@ -1,0 +1,212 @@
+packages:
+  python:
+    # buildable: false
+    externals:
+    - spec: python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-attrs:
+    # buildable: false
+    externals:
+    - spec: py-attrs@21.4.0-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-atomicwrites:
+    # buildable: false
+    externals:
+    - spec: py-atomicwrites@1.4.0-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-cython:
+    # buildable: false
+    externals:
+    - spec: py-cython@0.29.28-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-dask:
+    # buildable: false
+    externals:
+    - spec: py-dask@2022.2.1-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-iniconfig:
+    # buildable: false
+    externals:
+    - spec: py-iniconfig@1.1.1-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-locket:
+    # buildable: false
+    externals:
+    - spec: py-locket@0.2.1-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-fsspec:
+    # buildable: false
+    externals:
+    - spec: py-fsspec@2022.3.0-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-more-itertools:
+    # buildable: false
+    externals:
+    - spec: py-more-itertools@8.10.0-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-mpi4py:
+    # buildable: false
+    externals:
+    - spec: py-mpi4py@3.1.3-cray ^python@3.9.13.1-cray ^cray-mpich
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-nose:
+    # buildable: false
+    externals:
+    - spec: py-nose@1.3.7-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-numpy:
+    # buildable: false
+    externals:
+    - spec: py-numpy@1.21.5-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-packaging:
+    # buildable: false
+    externals:
+    - spec: py-packaging@21.3-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-pandas:
+    # buildable: false
+    externals:
+    - spec: py-pandas@1.4.2-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-partd:
+    # buildable: false
+    externals:
+    - spec: py-partd@1.2.0-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-pip:
+    # buildable: false
+    externals:
+    - spec: py-pip@22.0.4-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-py:
+    # buildable: false
+    externals:
+    - spec: py-py@1.11.0-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-python-dateutil:
+    # buildable: false
+    externals:
+    - spec: py-python-dateutil@2.8.2-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-pybind11:
+    # buildable: false
+    externals:
+    - spec: py-pybind11@2.6.2-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-pyparsing:
+    # buildable: false
+    externals:
+    - spec: py-pyparsing@3.0.4-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-pytz:
+    # buildable: false
+    externals:
+    - spec: py-pytz@2022.3-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-pyyaml:
+    # buildable: false
+    externals:
+    - spec: py-pyyaml@6.0-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-scipy:
+    # buildable: false
+    externals:
+    - spec: py-scipy@1.6.2-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-setuptools:
+    # buildable: false
+    externals:
+    - spec: py-setuptools@58.1.0-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-setuptools-scm:
+    # buildable: false
+    externals:
+    - spec: py-setuptools-scm@6.0.1-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-six:
+    # buildable: false
+    externals:
+    - spec: py-six@1.16.0-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-toml:
+    # buildable: false
+    externals:
+    - spec: py-toml@0.10.2-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-toolz:
+    # buildable: false
+    externals:
+    - spec: py-toolz@0.11.2-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-wcwidth:
+    # buildable: false
+    externals:
+    - spec: py-wcwidth@0.2.5-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+  py-zipp:
+    # buildable: false
+    externals:
+    - spec: py-zipp@0.0.0-cray ^python@3.9.13.1-cray
+      modules:
+      - cray-python/3.9.13.1
+      prefix: /opt/cray/pe/python/3.9.13.1/
+

--- a/frontier/cray-python/3.9.13.1/packages.yaml
+++ b/frontier/cray-python/3.9.13.1/packages.yaml
@@ -125,13 +125,13 @@ packages:
       modules:
       - cray-python/3.9.13.1
       prefix: /opt/cray/pe/python/3.9.13.1/
-  py-pybind11:
-    # buildable: false
-    externals:
-    - spec: py-pybind11@2.6.2-cray ^python@3.9.13.1-cray
-      modules:
-      - cray-python/3.9.13.1
-      prefix: /opt/cray/pe/python/3.9.13.1/
+  # py-pybind11:
+  #   # buildable: false
+  #   externals:
+  #   - spec: py-pybind11@2.6.2-cray ^python@3.9.13.1-cray
+  #     modules:
+  #     - cray-python/3.9.13.1
+  #     prefix: /opt/cray/pe/python/3.9.13.1/lib/python3.9/site-packages/pybind11/
   py-pyparsing:
     # buildable: false
     externals:

--- a/frontier/environment.yaml
+++ b/frontier/environment.yaml
@@ -1,0 +1,7 @@
+environment:
+  set:
+    MPICH_GPU_SUPPORT_ENABLED: 1
+  append:
+    CFLAGS: -I/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/include -L/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/lib -lmpi -L/opt/cray/pe/mpich/8.1.23/gtl/lib -lmpi_gtl_hsa
+    CXXFLAGS: -I/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/include -L/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/lib -lmpi -L/opt/cray/pe/mpich/8.1.23/gtl/lib -lmpi_gtl_hsa
+    HIPFLAGS: -I/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/include -L/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/lib -lmpi -L/opt/cray/pe/mpich/8.1.23/gtl/lib -lmpi_gtl_hsa

--- a/frontier/mirrors.yaml
+++ b/frontier/mirrors.yaml
@@ -1,0 +1,2 @@
+mirrors:
+  frontier-gcc: file:///lustre/orion/world-shared/csc444/spack/mirrors/frontier-gcc/

--- a/frontier/mirrors.yaml
+++ b/frontier/mirrors.yaml
@@ -1,2 +1,2 @@
 mirrors:
-  frontier-gcc: file:///lustre/orion/world-shared/csc444/spack/mirrors/frontier-gcc/
+  data-vis-sdk: file:///lustre/orion/world-shared/csc444/spack/mirrors/data-vis-sdk/

--- a/frontier/packages.yaml
+++ b/frontier/packages.yaml
@@ -58,6 +58,12 @@ packages:
     - spec: libfabric@1.15.2.0
       modules:
       - libfabric/1.15.2.0
+  libffi:
+    require: ["%gcc@7.5.0-system"]
+    # buildable: false
+    # externals:
+    # - spec: libffi@3
+    #   prefix: /usr
   paraview:
     require: ~qt+osmesa
   mesa:

--- a/frontier/packages.yaml
+++ b/frontier/packages.yaml
@@ -5,21 +5,22 @@ packages:
       mpi:: [cray-mpich]
       libllvm:: [llvm-amdgpu]
       gl:: [osmesa]
-      osmesa:: [mesa+osmesa]
+      libosmesa:: [mesa+osmesa]
 
   # System packages
   openssh:
     buildable: false
     externals:
-    - spec: openssh@8.4p1
+    - spec: "openssh@8.4p1 %gcc@7.5.0-system"
       prefix: /usr
   openssl:
     buildable: false
     externals:
-    - spec: openssl@1.1.1l
+    - spec: "openssl@1.1.1l %gcc@7.5.0-system"
       prefix: /usr
 
   cmake:
+    require: ["%gcc@7.5.0-system"]
     version: [3.26.1]
     variants: +ownlibs~qt~doc+ncurses
   # Cray provided packages
@@ -59,18 +60,21 @@ packages:
       - libfabric/1.15.2.0
   libffi:
     require: ["%gcc@7.5.0-system"]
+    # py-cffi requires libffi.so.8 which is not on this system
     # buildable: false
     # externals:
-    # - spec: libffi@3
+    # - spec: libffi@3 # %gcc@7.5.0-system
     #   prefix: /usr
   paraview:
-    require: ~qt+osmesa
+    require:
+    - ~qt+osmesa
   mesa:
-    require: +llvm~glx+osmesa
+    require:
+    - +llvm~glx+osmesa
   ncurses:
     buildable: false
     externals:
-    - spec: ncurses@6.4%gcc@11.2.0~symlinks+termlib
+    - spec: "ncurses@6.4-system~symlinks+termlib %gcc@7.5.0-system"
       prefix: /usr/
   visit:
     require: ~gui+osmesa

--- a/frontier/packages.yaml
+++ b/frontier/packages.yaml
@@ -1,0 +1,66 @@
+packages:
+  all:
+    providers:
+      blas:: [cray-libsci]
+      mpi:: [cray-mpich]
+      libllvm:: [llvm-amdgpu]
+      gl:: [osmesa]
+      osmesa:: [mesa+osmesa]
+
+  # System packages
+  openssh:
+    buildable: false
+    externals:
+    - spec: openssh@8.4p1
+      prefix: /usr
+  openssl:
+    buildable: false
+    externals:
+    - spec: openssl@1.1.1l
+      prefix: /usr
+
+  cmake:
+    version: [3.26.1]
+    variants: +ownlibs~qt~doc+ncurses
+  # Cray provided packages
+  cray-libsci:
+    buildable: false
+    externals:
+    - spec: cray-libsci@22.12.1.1 +openmp+mpi
+      modules: [cray-libsci/22.12.1.1]
+  cray-mpich:
+    buildable: false
+    externals:
+    - spec: cray-mpich@8.1.23 %gcc
+      prefix: /opt/cray/pe/mpich/8.1.23/ofi/gnu/9.1
+      modules:
+      - cray-mpich/8.1.23
+      - libfabric/1.15.2.0
+    - spec: cray-mpich@8.1.23 %cce
+      prefix: /opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0
+      modules:
+      - cray-mpich/8.1.23
+      - libfabric/1.15.2.0
+    - spec: cray-mpich@8.1.17 %clang@14.0.0-rocm5.2.0
+      prefix: /opt/cray/pe/mpich/8.1.23/ofi/amd/5.0
+      modules:
+      - cray-mpich/8.1.23
+      - libfabric/1.15.2.0
+    - spec: cray-mpich@8.1.17 %clang@15.0.0-rocm5.4.3
+      prefix: /opt/cray/pe/mpich/8.1.23/ofi/amd/5.0
+      modules:
+      - cray-mpich/8.1.23
+      - libfabric/1.15.2.0
+
+  libfabric:
+    buildable: false
+    externals:
+    - spec: libfabric@1.15.2.0
+      modules:
+      - libfabric/1.15.2.0
+  paraview:
+    require: ~qt+osmesa
+  mesa:
+    require: +llvm~glx+osmesa
+  visit:
+    require: ~gui+osmesa

--- a/frontier/packages.yaml
+++ b/frontier/packages.yaml
@@ -41,7 +41,7 @@ packages:
       modules:
       - cray-mpich/8.1.23
       - libfabric/1.15.2.0
-    - spec: cray-mpich@8.1.17 %clang@14.0.0-rocm5.2.0
+    - spec: cray-mpich@8.1.17 %clang@15.0.0-rocm5.3.0
       prefix: /opt/cray/pe/mpich/8.1.23/ofi/amd/5.0
       modules:
       - cray-mpich/8.1.23
@@ -51,7 +51,6 @@ packages:
       modules:
       - cray-mpich/8.1.23
       - libfabric/1.15.2.0
-
   libfabric:
     buildable: false
     externals:
@@ -68,5 +67,10 @@ packages:
     require: ~qt+osmesa
   mesa:
     require: +llvm~glx+osmesa
+  ncurses:
+    buildable: false
+    externals:
+    - spec: ncurses@6.4%gcc@11.2.0~symlinks+termlib
+      prefix: /usr/
   visit:
     require: ~gui+osmesa

--- a/frontier/rocm-5.3.0/compilers.yaml
+++ b/frontier/rocm-5.3.0/compilers.yaml
@@ -1,0 +1,30 @@
+compilers:
+- compiler:
+    spec: clang@15.0.0-rocm5.3.0
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    operating_system: sles15
+    modules:
+    - PrgEnv-amd
+    - amd/5.3.0
+    - xpmem
+    - craype-x86-trento
+    - libfabric
+    - cray-pmi/6.1.8
+    environment:
+      set:
+        RFE_811452_DISABLE: '1'
+      append_path:
+        PKG_CONFIG_PATH: /opt/cray/xpmem/2.5.2-2.4_3.45__gd0f7936.shasta/lib64/pkgconfig:/usr/lib64/pkgconfig
+        LD_LIBRARY_PATH: /opt/cray/pe/gcc-libs:/opt/cray/libfabric/1.15.2.0/lib64
+      prepend_path:
+        LD_LIBRARY_PATH: /opt/cray/pe/pmi/6.1.8/lib
+        LIBRARY_PATH: /opt/rocm-5.3.0/lib:/opt/rocm-5.3.0/lib64
+    extra_rpaths:
+    - /opt/rocm-5.3.0/lib
+    - /opt/rocm-5.3.0/lib64
+    - /opt/cray/pe/gcc-libs
+    - /opt/cray/gcc-libs

--- a/frontier/rocm-5.3.0/packages.yaml
+++ b/frontier/rocm-5.3.0/packages.yaml
@@ -174,7 +174,7 @@ packages:
       prefix: /opt/rocm-5.3.0/
       modules:
       - rocm/5.3.0
-      extra_atributes:
+      extra_attributes:
         compilers:
           c: /opt/rocm-5.3.0/llvm/bin/clang++
           cxx: /opt/rocm-5.3.0/llvm/bin/clang++

--- a/frontier/rocm-5.3.0/packages.yaml
+++ b/frontier/rocm-5.3.0/packages.yaml
@@ -1,0 +1,235 @@
+packages:
+  # ROCm 5.3.0
+  comgr:
+    buildable: false
+    externals:
+    - spec: comgr@5.3.0
+      prefix: /opt/rocm-5.3.0/
+      modules:
+      - rocm/5.3.0
+  hip-rocclr:
+    buildable: false
+    externals:
+    - spec: hip-rocclr@5.3.0
+      prefix: /opt/rocm-5.3.0/hip
+      modules:
+      - rocm/5.3.0
+  hipblas:
+    buildable: false
+    externals:
+    - spec: hipblas@5.3.0
+      prefix: /opt/rocm-5.3.0/
+      modules:
+      - rocm/5.3.0
+  hipcub:
+    buildable: false
+    externals:
+    - spec: hipcub@5.3.0
+      prefix: /opt/rocm-5.3.0/
+      modules:
+      - rocm/5.3.0
+  hipfft:
+    buildable: false
+    externals:
+    - spec: hipfft@5.3.0
+      prefix: /opt/rocm-5.3.0/
+      modules:
+      - rocm/5.3.0
+  hipsparse:
+    buildable: false
+    externals:
+    - spec: hipsparse@5.3.0
+      prefix: /opt/rocm-5.3.0/
+      modules:
+      - rocm/5.3.0
+  miopen-hip:
+    buildable: false
+    externals:
+    - spec: hip-rocclr@5.3.0
+      prefix: /opt/rocm-5.3.0/
+      modules:
+      - rocm/5.3.0
+  miopengemm:
+    buildable: false
+    externals:
+    - spec: miopengemm@5.3.0
+      prefix: /opt/rocm-5.3.0/
+      modules:
+      - rocm/5.3.0
+  rccl:
+    buildable: false
+    externals:
+    - spec: rccl@5.3.0
+      prefix: /opt/rocm-5.3.0/
+      modules:
+      - rocm/5.3.0
+  rocblas:
+    buildable: false
+    externals:
+    - spec: rocblas@5.3.0
+      prefix: /opt/rocm-5.3.0/
+      modules:
+      - rocm/5.3.0
+  rocfft:
+    buildable: false
+    externals:
+    - spec: rocfft@5.3.0
+      prefix: /opt/rocm-5.3.0/
+      modules:
+      - rocm/5.3.0
+  rocm-clang-ocl:
+    buildable: false
+    externals:
+    - spec: rocm-clang-ocl@5.3.0
+      prefix: /opt/rocm-5.3.0/
+      modules:
+      - rocm/5.3.0
+  rocm-cmake:
+    buildable: false
+    externals:
+    - spec: rocm-cmake@5.3.0
+      prefix: /opt/rocm-5.3.0/
+      modules:
+      - rocm/5.3.0
+  rocm-dbgapi:
+    buildable: false
+    externals:
+    - spec: rocm-dbgapi@5.3.0
+      prefix: /opt/rocm-5.3.0/
+      modules:
+      - rocm/5.3.0
+  rocm-debug-agent:
+    buildable: false
+    externals:
+    - spec: rocm-debug-agent@5.3.0
+      prefix: /opt/rocm-5.3.0/
+      modules:
+      - rocm/5.3.0
+  rocm-device-libs:
+    buildable: false
+    externals:
+    - spec: rocm-device-libs@5.3.0
+      prefix: /opt/rocm-5.3.0/
+      modules:
+      - rocm/5.3.0
+  rocm-gdb:
+    buildable: false
+    externals:
+    - spec: rocm-gdb@5.3.0
+      prefix: /opt/rocm-5.3.0/
+      modules:
+      - rocm/5.3.0
+  rocm-opencl:
+    buildable: false
+    externals:
+    - spec: rocm-opencl@5.3.0
+      prefix: /opt/rocm-5.3.0/opencl
+      modules:
+      - rocm/5.3.0
+  rocm-smi-lib:
+    buildable: false
+    externals:
+    - spec: rocm-smi-lib@5.3.0
+      prefix: /opt/rocm-5.3.0/
+      modules:
+      - rocm/5.3.0
+  hip:
+    buildable: false
+    externals:
+    - spec: hip@5.3.0
+      prefix: /opt/rocm-5.3.0
+      modules:
+      - craype-accel-amd-gfx90a
+      - rocm/5.3.0
+      extra_attributes:
+        compilers:
+          c: /opt/rocm-5.3.0/llvm/bin/clang++
+          c++: /opt/rocm-5.3.0/llvm/bin/clang++
+          hip: /opt/rocm-5.3.0/hip/bin/hipcc
+      environment:
+        set:
+          MPICH_GPU_SUPPORT_ENABLED: 1 
+  llvm-amdgpu:
+    buildable: false
+    externals:
+    - spec: llvm-amdgpu@5.3.0
+      prefix: /opt/rocm-5.3.0/llvm
+      modules:
+      - rocm/5.3.0
+      extra_attributes:
+        compilers:
+          c: /opt/rocm-5.3.0/llvm/bin/clang++
+          cxx: /opt/rocm-5.3.0/llvm/bin/clang++
+  hsakmt-roct:
+    buildable: false
+    externals:
+    - spec: hsakmt-roct@5.3.0
+      prefix: /opt/rocm-5.3.0/
+      modules:
+      - rocm/5.3.0
+  hsa-rocr-dev:
+    buildable: false
+    externals:
+    - spec: hsa-rocr-dev@5.3.0
+      prefix: /opt/rocm-5.3.0/
+      modules:
+      - rocm/5.3.0
+      extra_atributes:
+        compilers:
+          c: /opt/rocm-5.3.0/llvm/bin/clang++
+          cxx: /opt/rocm-5.3.0/llvm/bin/clang++
+  roctracer-dev-api:
+    buildable: false
+    externals:
+    - spec: roctracer-dev-api@5.3.0
+      prefix: /opt/rocm-5.3.0/roctracer
+      modules:
+      - rocm/5.3.0
+  rocprim:
+    buildable: false
+    externals:
+    - spec: rocprim@5.3.0
+      prefix: /opt/rocm-5.3.0
+      modules:
+      - rocm/5.3.0
+  rocrand:
+    buildable: false
+    externals:
+    - spec: rocrand@5.3.0
+      prefix: /opt/rocm-5.3.0
+      modules:
+      - rocm/5.3.0
+  hipsolver:
+    buildable: false
+    externals:
+    - spec: hipsolver@5.3.0
+      prefix: /opt/rocm-5.3.0
+      modules: [rocm/5.3.0]    
+  rocsolver:
+    buildable: false
+    externals:
+    - spec: rocsolver@5.3.0
+      prefix: /opt/rocm-5.3.0
+      modules:
+      - rocm/5.3.0
+  rocsparse:
+    buildable: false
+    externals:
+    - spec: rocsparse@5.3.0
+      prefix: /opt/rocm-5.3.0
+      modules:
+      - rocm/5.3.0
+  rocthrust:
+    buildable: false
+    externals:
+    - spec: rocthrust@5.3.0
+      prefix: /opt/rocm-5.3.0
+      modules:
+      - rocm/5.3.0
+  rocprofiler-dev:
+    buildable: false
+    externals:
+    - spec: rocprofiler-dev@5.3.0
+      prefix: /opt/rocm-5.3.0
+      modules:
+      - rocm/5.3.0

--- a/frontier/rocm-5.4.3/compilers.yaml
+++ b/frontier/rocm-5.4.3/compilers.yaml
@@ -1,0 +1,31 @@
+compilers:
+- compiler:
+    spec: clang@15.0.0-rocm5.4.3
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    operating_system: sles15
+    modules:
+    - PrgEnv-amd
+    - amd/5.4.3
+    - xpmem
+    - craype-x86-trento
+    - libfabric
+    - cray-pmi/6.1.8
+    environment:
+      set:
+        RFE_811452_DISABLE: '1'
+      append_path:
+        PKG_CONFIG_PATH: /opt/cray/xpmem/2.5.2-2.4_3.45__gd0f7936.shasta/lib64/pkgconfig:/usr/lib64/pkgconfig
+        LD_LIBRARY_PATH: /opt/cray/pe/gcc-libs:/opt/cray/libfabric/1.15.2.0/lib64
+        LD_PRELOAD: /opt/cray/pe/libsci/22.12.1.1/CRAY/9.0/x86_64/lib/libsci_cray_mp.so.5
+      prepend_path:
+        LD_LIBRARY_PATH: /opt/cray/pe/pmi/6.1.8/lib
+        LIBRARY_PATH: /opt/rocm-5.4.3/lib:/opt/rocm-5.4.3/lib64
+    extra_rpaths:
+    - /opt/rocm-5.4.3/lib
+    - /opt/rocm-5.4.3/lib64
+    - /opt/cray/pe/gcc-libs
+    - /opt/cray/gcc-libs

--- a/frontier/rocm-5.4.3/packages.yaml
+++ b/frontier/rocm-5.4.3/packages.yaml
@@ -200,7 +200,7 @@ packages:
       prefix: /opt/rocm-5.4.3/
       modules:
       - rocm/5.4.3
-      extra_atributes:
+      extra_attributes:
         compilers:
           c: /opt/rocm-5.4.3/llvm/bin/clang++
           cxx: /opt/rocm-5.4.3/llvm/bin/clang++

--- a/frontier/rocm-5.4.3/packages.yaml
+++ b/frontier/rocm-5.4.3/packages.yaml
@@ -1,0 +1,261 @@
+packages:
+  # ROCm 5.4.3
+  comgr:
+    buildable: false
+    externals:
+    - spec: comgr@5.4.3
+      prefix: /opt/rocm-5.4.3/
+      modules:
+      - rocm/5.4.3
+  hip-rocclr:
+    buildable: false
+    externals:
+    - spec: hip-rocclr@5.4.3
+      prefix: /opt/rocm-5.4.3/hip
+      modules:
+      - rocm/5.4.3
+  hipblas:
+    buildable: false
+    externals:
+    - spec: hipblas@5.4.3
+      prefix: /opt/rocm-5.4.3/
+      modules:
+      - rocm/5.4.3
+  hipcub:
+    buildable: false
+    externals:
+    - spec: hipcub@5.4.3
+      prefix: /opt/rocm-5.4.3/
+      modules:
+      - rocm/5.4.3
+  hipfft:
+    buildable: false
+    externals:
+    - spec: hipfft@5.4.3
+      prefix: /opt/rocm-5.4.3/
+      modules:
+      - rocm/5.4.3
+  hipsparse:
+    buildable: false
+    externals:
+    - spec: hipsparse@5.4.3
+      prefix: /opt/rocm-5.4.3/
+      modules:
+      - rocm/5.4.3
+  miopen-hip:
+    buildable: false
+    externals:
+    - spec: hip-rocclr@5.4.3
+      prefix: /opt/rocm-5.4.3/
+      modules:
+      - rocm/5.4.3
+  miopengemm:
+    buildable: false
+    externals:
+    - spec: miopengemm@5.4.3
+      prefix: /opt/rocm-5.4.3/
+      modules:
+      - rocm/5.4.3
+  rccl:
+    buildable: false
+    externals:
+    - spec: rccl@5.4.3
+      prefix: /opt/rocm-5.4.3/
+      modules:
+      - rocm/5.4.3
+  rocblas:
+    buildable: false
+    externals:
+    - spec: rocblas@5.4.3
+      prefix: /opt/rocm-5.4.3/
+      modules:
+      - rocm/5.4.3
+  rocfft:
+    buildable: false
+    externals:
+    - spec: rocfft@5.4.3
+      prefix: /opt/rocm-5.4.3/
+      modules:
+      - rocm/5.4.3
+  rocm-clang-ocl:
+    buildable: false
+    externals:
+    - spec: rocm-clang-ocl@5.4.3
+      prefix: /opt/rocm-5.4.3/
+      modules:
+      - rocm/5.4.3
+  rocm-cmake:
+    buildable: false
+    externals:
+    - spec: rocm-cmake@5.4.3
+      prefix: /opt/rocm-5.4.3/
+      modules:
+      - rocm/5.4.3
+  rocm-dbgapi:
+    buildable: false
+    externals:
+    - spec: rocm-dbgapi@5.4.3
+      prefix: /opt/rocm-5.4.3/
+      modules:
+      - rocm/5.4.3
+  rocm-debug-agent:
+    buildable: false
+    externals:
+    - spec: rocm-debug-agent@5.4.3
+      prefix: /opt/rocm-5.4.3/
+      modules:
+      - rocm/5.4.3
+  rocm-device-libs:
+    buildable: false
+    externals:
+    - spec: rocm-device-libs@5.4.3
+      prefix: /opt/rocm-5.4.3/
+      modules:
+      - rocm/5.4.3
+  rocm-gdb:
+    buildable: false
+    externals:
+    - spec: rocm-gdb@5.4.3
+      prefix: /opt/rocm-5.4.3/
+      modules:
+      - rocm/5.4.3
+  rocm-opencl:
+    buildable: false
+    externals:
+    - spec: rocm-opencl@5.4.3
+      prefix: /opt/rocm-5.4.3/opencl
+      modules:
+      - rocm/5.4.3
+  rocm-smi-lib:
+    buildable: false
+    externals:
+    - spec: rocm-smi-lib@5.4.3
+      prefix: /opt/rocm-5.4.3/
+      modules:
+      - rocm/5.4.3
+  hip:
+    buildable: false
+    externals:
+    - spec: hip@5.4.3 %gcc@12.2.0
+      prefix: /opt/rocm-5.4.3
+      modules:
+      - craype-accel-amd-gfx90a
+      - rocm/5.4.3
+      extra_attributes:
+        compilers:
+          c: /opt/rocm-5.4.3/llvm/bin/clang++
+          c++: /opt/rocm-5.4.3/llvm/bin/clang++
+          hip: /opt/rocm-5.4.3/hip/bin/hipcc
+      environment:
+        set:
+          MPICH_GPU_SUPPORT_ENABLED: 1 
+    - spec: hip@5.4.3 %cce
+      prefix: /opt/rocm-5.4.3
+      modules:
+      - craype-accel-amd-gfx90a
+      - rocm/5.4.3
+      extra_attributes:
+        compilers:
+          c: /opt/rocm-5.4.3/llvm/bin/clang++
+          c++: /opt/rocm-5.4.3/llvm/bin/clang++
+          hip: /opt/rocm-5.4.3/hip/bin/hipcc
+      environment:
+        set:
+          MPICH_GPU_SUPPORT_ENABLED: 1 
+    - spec: hip@5.4.3 %clang@15.0.0-rocm5.4.3
+      prefix: /opt/rocm-5.4.3
+      modules:
+      - craype-accel-amd-gfx90a
+      - rocm/5.4.3
+      extra_attributes:
+        compilers:
+          c: /opt/rocm-5.4.3/llvm/bin/clang++
+          c++: /opt/rocm-5.4.3/llvm/bin/clang++
+          hip: /opt/rocm-5.4.3/hip/bin/hipcc
+      environment:
+        set:
+          MPICH_GPU_SUPPORT_ENABLED: 1 
+  llvm-amdgpu:
+    buildable: false
+    externals:
+    - spec: llvm-amdgpu@5.4.3
+      prefix: /opt/rocm-5.4.3/llvm
+      modules:
+      - rocm/5.4.3
+      extra_attributes:
+        compilers:
+          c: /opt/rocm-5.4.3/llvm/bin/clang++
+          cxx: /opt/rocm-5.4.3/llvm/bin/clang++
+  hsakmt-roct:
+    buildable: false
+    externals:
+    - spec: hsakmt-roct@5.4.3
+      prefix: /opt/rocm-5.4.3/
+      modules:
+      - rocm/5.4.3
+  hsa-rocr-dev:
+    buildable: false
+    externals:
+    - spec: hsa-rocr-dev@5.4.3
+      prefix: /opt/rocm-5.4.3/
+      modules:
+      - rocm/5.4.3
+      extra_atributes:
+        compilers:
+          c: /opt/rocm-5.4.3/llvm/bin/clang++
+          cxx: /opt/rocm-5.4.3/llvm/bin/clang++
+  roctracer-dev-api:
+    buildable: false
+    externals:
+    - spec: roctracer-dev-api@5.4.3
+      prefix: /opt/rocm-5.4.3/roctracer
+      modules:
+      - rocm/5.4.3
+  rocprim:
+    buildable: false
+    externals:
+    - spec: rocprim@5.4.3
+      prefix: /opt/rocm-5.4.3
+      modules:
+      - rocm/5.4.3
+  rocrand:
+    buildable: false
+    externals:
+    - spec: rocrand@5.4.3
+      prefix: /opt/rocm-5.4.3
+      modules:
+      - rocm/5.4.3
+  hipsolver:
+    buildable: false
+    externals:
+    - spec: hipsolver@5.4.3
+      prefix: /opt/rocm-5.4.3
+      modules: [rocm/5.4.3]    
+  rocsolver:
+    buildable: false
+    externals:
+    - spec: rocsolver@5.4.3
+      prefix: /opt/rocm-5.4.3
+      modules:
+      - rocm/5.4.3
+  rocsparse:
+    buildable: false
+    externals:
+    - spec: rocsparse@5.4.3
+      prefix: /opt/rocm-5.4.3
+      modules:
+      - rocm/5.4.3
+  rocthrust:
+    buildable: false
+    externals:
+    - spec: rocthrust@5.4.3
+      prefix: /opt/rocm-5.4.3
+      modules:
+      - rocm/5.4.3
+  rocprofiler-dev:
+    buildable: false
+    externals:
+    - spec: rocprofiler-dev@5.4.3
+      prefix: /opt/rocm-5.4.3
+      modules:
+      - rocm/5.4.3


### PR DESCRIPTION
Some reversions for Crusher (not that they matter much now), and updates for frontier.

In order to make it easier to test and switch between different ROCm environments, I create a differetn directory for each ROCm version. The usage for these is...

```yaml
spack:
  include:
  - $user_config_prefix/rocm-5.3.0
  specs:
  - zlib
```