### PR TITLE
Add configuration for ROCm 6.0.0 on Frontier

### DIFF
--- a/frontier/rocm-6.0.0/compilers.yaml
+++ b/frontier/rocm-6.0.0/compilers.yaml
@@ -1,0 +1,30 @@
+compilers:
+- compiler:
+    spec: clang@15.0.0-rocm6.0.0
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    operating_system: sles15
+    modules:
+    - PrgEnv-amd
+    - amd/6.0.0
+    - xpmem
+    - craype-x86-trento
+    - libfabric
+    - cray-pmi/6.1.8
+    environment:
+      set:
+        RFE_811452_DISABLE: '1'
+      append_path:
+        PKG_CONFIG_PATH: /opt/cray/xpmem/2.5.2-2.4_3.45__gd0f7936.shasta/lib64/pkgconfig:/usr/lib64/pkgconfig
+        LD_LIBRARY_PATH: /opt/cray/pe/gcc-libs:/opt/cray/libfabric/1.15.2.0/lib64
+      prepend_path:
+        LD_LIBRARY_PATH: /opt/cray/pe/pmi/6.1.8/lib
+        LIBRARY_PATH: /opt/rocm-6.0.0/lib:/opt/rocm-6.0.0/lib64
+    extra_rpaths:
+    - /opt/rocm-6.0.0/lib
+    - /opt/rocm-6.0.0/lib64
+    - /opt/cray/pe/gcc-libs
+    - /opt/cray/gcc-libs

--- a/frontier/rocm-6.0.0/packages.yaml
+++ b/frontier/rocm-6.0.0/packages.yaml
@@ -1,0 +1,235 @@
+packages:
+  # ROCm 6.0.0
+  comgr:
+    buildable: false
+    externals:
+    - spec: comgr@6.0.0
+      prefix: /opt/rocm-6.0.0/
+      modules:
+      - rocm/6.0.0
+  hip-rocclr:
+    buildable: false
+    externals:
+    - spec: hip-rocclr@6.0.0
+      prefix: /opt/rocm-6.0.0/hip
+      modules:
+      - rocm/6.0.0
+  hipblas:
+    buildable: false
+    externals:
+    - spec: hipblas@6.0.0
+      prefix: /opt/rocm-6.0.0/
+      modules:
+      - rocm/6.0.0
+  hipcub:
+    buildable: false
+    externals:
+    - spec: hipcub@6.0.0
+      prefix: /opt/rocm-6.0.0/
+      modules:
+      - rocm/6.0.0
+  hipfft:
+    buildable: false
+    externals:
+    - spec: hipfft@6.0.0
+      prefix: /opt/rocm-6.0.0/
+      modules:
+      - rocm/6.0.0
+  hipsparse:
+    buildable: false
+    externals:
+    - spec: hipsparse@6.0.0
+      prefix: /opt/rocm-6.0.0/
+      modules:
+      - rocm/6.0.0
+  miopen-hip:
+    buildable: false
+    externals:
+    - spec: hip-rocclr@6.0.0
+      prefix: /opt/rocm-6.0.0/
+      modules:
+      - rocm/6.0.0
+  miopengemm:
+    buildable: false
+    externals:
+    - spec: miopengemm@6.0.0
+      prefix: /opt/rocm-6.0.0/
+      modules:
+      - rocm/6.0.0
+  rccl:
+    buildable: false
+    externals:
+    - spec: rccl@6.0.0
+      prefix: /opt/rocm-6.0.0/
+      modules:
+      - rocm/6.0.0
+  rocblas:
+    buildable: false
+    externals:
+    - spec: rocblas@6.0.0
+      prefix: /opt/rocm-6.0.0/
+      modules:
+      - rocm/6.0.0
+  rocfft:
+    buildable: false
+    externals:
+    - spec: rocfft@6.0.0
+      prefix: /opt/rocm-6.0.0/
+      modules:
+      - rocm/6.0.0
+  rocm-clang-ocl:
+    buildable: false
+    externals:
+    - spec: rocm-clang-ocl@6.0.0
+      prefix: /opt/rocm-6.0.0/
+      modules:
+      - rocm/6.0.0
+  rocm-cmake:
+    buildable: false
+    externals:
+    - spec: rocm-cmake@6.0.0
+      prefix: /opt/rocm-6.0.0/
+      modules:
+      - rocm/6.0.0
+  rocm-dbgapi:
+    buildable: false
+    externals:
+    - spec: rocm-dbgapi@6.0.0
+      prefix: /opt/rocm-6.0.0/
+      modules:
+      - rocm/6.0.0
+  rocm-debug-agent:
+    buildable: false
+    externals:
+    - spec: rocm-debug-agent@6.0.0
+      prefix: /opt/rocm-6.0.0/
+      modules:
+      - rocm/6.0.0
+  rocm-device-libs:
+    buildable: false
+    externals:
+    - spec: rocm-device-libs@6.0.0
+      prefix: /opt/rocm-6.0.0/
+      modules:
+      - rocm/6.0.0
+  rocm-gdb:
+    buildable: false
+    externals:
+    - spec: rocm-gdb@6.0.0
+      prefix: /opt/rocm-6.0.0/
+      modules:
+      - rocm/6.0.0
+  rocm-opencl:
+    buildable: false
+    externals:
+    - spec: rocm-opencl@6.0.0
+      prefix: /opt/rocm-6.0.0/opencl
+      modules:
+      - rocm/6.0.0
+  rocm-smi-lib:
+    buildable: false
+    externals:
+    - spec: rocm-smi-lib@6.0.0
+      prefix: /opt/rocm-6.0.0/
+      modules:
+      - rocm/6.0.0
+  hip:
+    buildable: false
+    externals:
+    - spec: hip@6.0.0
+      prefix: /opt/rocm-6.0.0
+      modules:
+      - craype-accel-amd-gfx90a
+      - rocm/6.0.0
+      extra_attributes:
+        compilers:
+          c: /opt/rocm-6.0.0/llvm/bin/clang++
+          c++: /opt/rocm-6.0.0/llvm/bin/clang++
+          hip: /opt/rocm-6.0.0/hip/bin/hipcc
+      environment:
+        set:
+          MPICH_GPU_SUPPORT_ENABLED: 1 
+  llvm-amdgpu:
+    buildable: false
+    externals:
+    - spec: llvm-amdgpu@6.0.0
+      prefix: /opt/rocm-6.0.0/llvm
+      modules:
+      - rocm/6.0.0
+      extra_attributes:
+        compilers:
+          c: /opt/rocm-6.0.0/llvm/bin/clang++
+          cxx: /opt/rocm-6.0.0/llvm/bin/clang++
+  hsakmt-roct:
+    buildable: false
+    externals:
+    - spec: hsakmt-roct@6.0.0
+      prefix: /opt/rocm-6.0.0/
+      modules:
+      - rocm/6.0.0
+  hsa-rocr-dev:
+    buildable: false
+    externals:
+    - spec: hsa-rocr-dev@6.0.0
+      prefix: /opt/rocm-6.0.0/
+      modules:
+      - rocm/6.0.0
+      extra_attributes:
+        compilers:
+          c: /opt/rocm-6.0.0/llvm/bin/clang++
+          cxx: /opt/rocm-6.0.0/llvm/bin/clang++
+  roctracer-dev-api:
+    buildable: false
+    externals:
+    - spec: roctracer-dev-api@6.0.0
+      prefix: /opt/rocm-6.0.0/roctracer
+      modules:
+      - rocm/6.0.0
+  rocprim:
+    buildable: false
+    externals:
+    - spec: rocprim@6.0.0
+      prefix: /opt/rocm-6.0.0
+      modules:
+      - rocm/6.0.0
+  rocrand:
+    buildable: false
+    externals:
+    - spec: rocrand@6.0.0
+      prefix: /opt/rocm-6.0.0
+      modules:
+      - rocm/6.0.0
+  hipsolver:
+    buildable: false
+    externals:
+    - spec: hipsolver@6.0.0
+      prefix: /opt/rocm-6.0.0
+      modules: [rocm/6.0.0]    
+  rocsolver:
+    buildable: false
+    externals:
+    - spec: rocsolver@6.0.0
+      prefix: /opt/rocm-6.0.0
+      modules:
+      - rocm/6.0.0
+  rocsparse:
+    buildable: false
+    externals:
+    - spec: rocsparse@6.0.0
+      prefix: /opt/rocm-6.0.0
+      modules:
+      - rocm/6.0.0
+  rocthrust:
+    buildable: false
+    externals:
+    - spec: rocthrust@6.0.0
+      prefix: /opt/rocm-6.0.0
+      modules:
+      - rocm/6.0.0
+  rocprofiler-dev:
+    buildable: false
+    externals:
+    - spec: rocprofiler-dev@6.0.0
+      prefix: /opt/rocm-6.0.0
+      modules:
+      - rocm/6.0.0


### PR DESCRIPTION
There is a known problem with ROCm 6.2 on Frontier (it is missing llvm-config), and this is the latest ROCm install that correctly provides it. Some packages (such as mesa) cannot configure themselves without llvm-config.