### PR TITLE
Add configuration for rocm 6.2.4

### DIFF
--- a/frontier/rocm-6.2.4/compilers.yaml
+++ b/frontier/rocm-6.2.4/compilers.yaml
@@ -1,0 +1,30 @@
+compilers:
+- compiler:
+    spec: clang@15.0.0-rocm6.2.4
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    operating_system: sles15
+    modules:
+    - PrgEnv-amd
+    - amd/6.2.4
+    - xpmem
+    - craype-x86-trento
+    - libfabric
+    - cray-pmi/6.1.8
+    environment:
+      set:
+        RFE_811452_DISABLE: '1'
+      append_path:
+        PKG_CONFIG_PATH: /opt/cray/xpmem/2.5.2-2.4_3.45__gd0f7936.shasta/lib64/pkgconfig:/usr/lib64/pkgconfig
+        LD_LIBRARY_PATH: /opt/cray/pe/gcc-libs:/opt/cray/libfabric/1.15.2.0/lib64
+      prepend_path:
+        LD_LIBRARY_PATH: /opt/cray/pe/pmi/6.1.8/lib
+        LIBRARY_PATH: /opt/rocm-6.2.4/lib:/opt/rocm-6.2.4/lib64
+    extra_rpaths:
+    - /opt/rocm-6.2.4/lib
+    - /opt/rocm-6.2.4/lib64
+    - /opt/cray/pe/gcc-libs
+    - /opt/cray/gcc-libs

--- a/frontier/rocm-6.2.4/packages.yaml
+++ b/frontier/rocm-6.2.4/packages.yaml
@@ -1,0 +1,235 @@
+packages:
+  # ROCm 6.2.4
+  comgr:
+    buildable: false
+    externals:
+    - spec: comgr@6.2.4
+      prefix: /opt/rocm-6.2.4/
+      modules:
+      - rocm/6.2.4
+  hip-rocclr:
+    buildable: false
+    externals:
+    - spec: hip-rocclr@6.2.4
+      prefix: /opt/rocm-6.2.4/hip
+      modules:
+      - rocm/6.2.4
+  hipblas:
+    buildable: false
+    externals:
+    - spec: hipblas@6.2.4
+      prefix: /opt/rocm-6.2.4/
+      modules:
+      - rocm/6.2.4
+  hipcub:
+    buildable: false
+    externals:
+    - spec: hipcub@6.2.4
+      prefix: /opt/rocm-6.2.4/
+      modules:
+      - rocm/6.2.4
+  hipfft:
+    buildable: false
+    externals:
+    - spec: hipfft@6.2.4
+      prefix: /opt/rocm-6.2.4/
+      modules:
+      - rocm/6.2.4
+  hipsparse:
+    buildable: false
+    externals:
+    - spec: hipsparse@6.2.4
+      prefix: /opt/rocm-6.2.4/
+      modules:
+      - rocm/6.2.4
+  miopen-hip:
+    buildable: false
+    externals:
+    - spec: hip-rocclr@6.2.4
+      prefix: /opt/rocm-6.2.4/
+      modules:
+      - rocm/6.2.4
+  miopengemm:
+    buildable: false
+    externals:
+    - spec: miopengemm@6.2.4
+      prefix: /opt/rocm-6.2.4/
+      modules:
+      - rocm/6.2.4
+  rccl:
+    buildable: false
+    externals:
+    - spec: rccl@6.2.4
+      prefix: /opt/rocm-6.2.4/
+      modules:
+      - rocm/6.2.4
+  rocblas:
+    buildable: false
+    externals:
+    - spec: rocblas@6.2.4
+      prefix: /opt/rocm-6.2.4/
+      modules:
+      - rocm/6.2.4
+  rocfft:
+    buildable: false
+    externals:
+    - spec: rocfft@6.2.4
+      prefix: /opt/rocm-6.2.4/
+      modules:
+      - rocm/6.2.4
+  rocm-clang-ocl:
+    buildable: false
+    externals:
+    - spec: rocm-clang-ocl@6.2.4
+      prefix: /opt/rocm-6.2.4/
+      modules:
+      - rocm/6.2.4
+  rocm-cmake:
+    buildable: false
+    externals:
+    - spec: rocm-cmake@6.2.4
+      prefix: /opt/rocm-6.2.4/
+      modules:
+      - rocm/6.2.4
+  rocm-dbgapi:
+    buildable: false
+    externals:
+    - spec: rocm-dbgapi@6.2.4
+      prefix: /opt/rocm-6.2.4/
+      modules:
+      - rocm/6.2.4
+  rocm-debug-agent:
+    buildable: false
+    externals:
+    - spec: rocm-debug-agent@6.2.4
+      prefix: /opt/rocm-6.2.4/
+      modules:
+      - rocm/6.2.4
+  rocm-device-libs:
+    buildable: false
+    externals:
+    - spec: rocm-device-libs@6.2.4
+      prefix: /opt/rocm-6.2.4/
+      modules:
+      - rocm/6.2.4
+  rocm-gdb:
+    buildable: false
+    externals:
+    - spec: rocm-gdb@6.2.4
+      prefix: /opt/rocm-6.2.4/
+      modules:
+      - rocm/6.2.4
+  rocm-opencl:
+    buildable: false
+    externals:
+    - spec: rocm-opencl@6.2.4
+      prefix: /opt/rocm-6.2.4/opencl
+      modules:
+      - rocm/6.2.4
+  rocm-smi-lib:
+    buildable: false
+    externals:
+    - spec: rocm-smi-lib@6.2.4
+      prefix: /opt/rocm-6.2.4/
+      modules:
+      - rocm/6.2.4
+  hip:
+    buildable: false
+    externals:
+    - spec: hip@6.2.4
+      prefix: /opt/rocm-6.2.4
+      modules:
+      - craype-accel-amd-gfx90a
+      - rocm/6.2.4
+      extra_attributes:
+        compilers:
+          c: /opt/rocm-6.2.4/llvm/bin/clang++
+          c++: /opt/rocm-6.2.4/llvm/bin/clang++
+          hip: /opt/rocm-6.2.4/hip/bin/hipcc
+      environment:
+        set:
+          MPICH_GPU_SUPPORT_ENABLED: 1 
+  llvm-amdgpu:
+    buildable: false
+    externals:
+    - spec: llvm-amdgpu@6.2.4
+      prefix: /opt/rocm-6.2.4/llvm
+      modules:
+      - rocm/6.2.4
+      extra_attributes:
+        compilers:
+          c: /opt/rocm-6.2.4/llvm/bin/clang++
+          cxx: /opt/rocm-6.2.4/llvm/bin/clang++
+  hsakmt-roct:
+    buildable: false
+    externals:
+    - spec: hsakmt-roct@6.2.4
+      prefix: /opt/rocm-6.2.4/
+      modules:
+      - rocm/6.2.4
+  hsa-rocr-dev:
+    buildable: false
+    externals:
+    - spec: hsa-rocr-dev@6.2.4
+      prefix: /opt/rocm-6.2.4/
+      modules:
+      - rocm/6.2.4
+      extra_attributes:
+        compilers:
+          c: /opt/rocm-6.2.4/llvm/bin/clang++
+          cxx: /opt/rocm-6.2.4/llvm/bin/clang++
+  roctracer-dev-api:
+    buildable: false
+    externals:
+    - spec: roctracer-dev-api@6.2.4
+      prefix: /opt/rocm-6.2.4/roctracer
+      modules:
+      - rocm/6.2.4
+  rocprim:
+    buildable: false
+    externals:
+    - spec: rocprim@6.2.4
+      prefix: /opt/rocm-6.2.4
+      modules:
+      - rocm/6.2.4
+  rocrand:
+    buildable: false
+    externals:
+    - spec: rocrand@6.2.4
+      prefix: /opt/rocm-6.2.4
+      modules:
+      - rocm/6.2.4
+  hipsolver:
+    buildable: false
+    externals:
+    - spec: hipsolver@6.2.4
+      prefix: /opt/rocm-6.2.4
+      modules: [rocm/6.2.4]    
+  rocsolver:
+    buildable: false
+    externals:
+    - spec: rocsolver@6.2.4
+      prefix: /opt/rocm-6.2.4
+      modules:
+      - rocm/6.2.4
+  rocsparse:
+    buildable: false
+    externals:
+    - spec: rocsparse@6.2.4
+      prefix: /opt/rocm-6.2.4
+      modules:
+      - rocm/6.2.4
+  rocthrust:
+    buildable: false
+    externals:
+    - spec: rocthrust@6.2.4
+      prefix: /opt/rocm-6.2.4
+      modules:
+      - rocm/6.2.4
+  rocprofiler-dev:
+    buildable: false
+    externals:
+    - spec: rocprofiler-dev@6.2.4
+      prefix: /opt/rocm-6.2.4
+      modules:
+      - rocm/6.2.4


### PR DESCRIPTION
I've recently had the need to upgrade to a more recent version of ROCm. Version 6.2.4 is now the default version on Frontier, so it makes sense to support it.