### PR TITLE
Fix the location of the environment configuration

### DIFF
--- a/frontier/rocm-5.3.0/packages.yaml
+++ b/frontier/rocm-5.3.0/packages.yaml
@@ -146,9 +146,9 @@ packages:
           c: /opt/rocm-5.3.0/llvm/bin/clang++
           c++: /opt/rocm-5.3.0/llvm/bin/clang++
           hip: /opt/rocm-5.3.0/hip/bin/hipcc
-      environment:
-        set:
-          MPICH_GPU_SUPPORT_ENABLED: 1 
+        environment:
+          set:
+            MPICH_GPU_SUPPORT_ENABLED: 1 
   llvm-amdgpu:
     buildable: false
     externals:

--- a/frontier/rocm-5.4.3/packages.yaml
+++ b/frontier/rocm-5.4.3/packages.yaml
@@ -146,9 +146,9 @@ packages:
           c: /opt/rocm-5.4.3/llvm/bin/clang++
           c++: /opt/rocm-5.4.3/llvm/bin/clang++
           hip: /opt/rocm-5.4.3/hip/bin/hipcc
-      environment:
-        set:
-          MPICH_GPU_SUPPORT_ENABLED: 1 
+        environment:
+          set:
+            MPICH_GPU_SUPPORT_ENABLED: 1 
     - spec: hip@5.4.3 %cce
       prefix: /opt/rocm-5.4.3
       modules:
@@ -159,9 +159,9 @@ packages:
           c: /opt/rocm-5.4.3/llvm/bin/clang++
           c++: /opt/rocm-5.4.3/llvm/bin/clang++
           hip: /opt/rocm-5.4.3/hip/bin/hipcc
-      environment:
-        set:
-          MPICH_GPU_SUPPORT_ENABLED: 1 
+        environment:
+          set:
+            MPICH_GPU_SUPPORT_ENABLED: 1 
     - spec: hip@5.4.3 %clang@15.0.0-rocm5.4.3
       prefix: /opt/rocm-5.4.3
       modules:
@@ -172,9 +172,9 @@ packages:
           c: /opt/rocm-5.4.3/llvm/bin/clang++
           c++: /opt/rocm-5.4.3/llvm/bin/clang++
           hip: /opt/rocm-5.4.3/hip/bin/hipcc
-      environment:
-        set:
-          MPICH_GPU_SUPPORT_ENABLED: 1 
+        environment:
+          set:
+            MPICH_GPU_SUPPORT_ENABLED: 1 
   llvm-amdgpu:
     buildable: false
     externals:

--- a/frontier/rocm-6.0.0/packages.yaml
+++ b/frontier/rocm-6.0.0/packages.yaml
@@ -146,9 +146,9 @@ packages:
           c: /opt/rocm-6.0.0/llvm/bin/clang++
           c++: /opt/rocm-6.0.0/llvm/bin/clang++
           hip: /opt/rocm-6.0.0/hip/bin/hipcc
-      environment:
-        set:
-          MPICH_GPU_SUPPORT_ENABLED: 1 
+        environment:
+          set:
+            MPICH_GPU_SUPPORT_ENABLED: 1 
   llvm-amdgpu:
     buildable: false
     externals:

--- a/frontier/rocm-6.2.0/packages.yaml
+++ b/frontier/rocm-6.2.0/packages.yaml
@@ -146,9 +146,9 @@ packages:
           c: /opt/rocm-6.2.0/llvm/bin/clang++
           c++: /opt/rocm-6.2.0/llvm/bin/clang++
           hip: /opt/rocm-6.2.0/hip/bin/hipcc
-      environment:
-        set:
-          MPICH_GPU_SUPPORT_ENABLED: 1 
+        environment:
+          set:
+            MPICH_GPU_SUPPORT_ENABLED: 1 
   llvm-amdgpu:
     buildable: false
     externals:

--- a/frontier/rocm-6.2.4/packages.yaml
+++ b/frontier/rocm-6.2.4/packages.yaml
@@ -146,9 +146,9 @@ packages:
           c: /opt/rocm-6.2.4/llvm/bin/clang
           c++: /opt/rocm-6.2.4/llvm/bin/clang++
           hip: /opt/rocm-6.2.4/hip/bin/hipcc
-      environment:
-        set:
-          MPICH_GPU_SUPPORT_ENABLED: 1 
+        environment:
+          set:
+            MPICH_GPU_SUPPORT_ENABLED: 1 
   llvm-amdgpu:
     buildable: false
     externals:


### PR DESCRIPTION
The environment configuration for compilers in the packages.yaml files was placed at the incorrect indentation. This was causing a failure with Spack 1.1.