### PR TITLE
Environment fixes for frontier

### DIFF
--- a/crusher/packages.yaml
+++ b/crusher/packages.yaml
@@ -174,7 +174,7 @@ packages:
           hip: /opt/rocm-5.4.0/hip/bin/hipcc
       environment:
         set:
-          MPICH_GPU_SUPPORT_ENABLED: 1 
+          MPICH_GPU_SUPPORT_ENABLED: "1"
   llvm-amdgpu:
     buildable: false
     externals:

--- a/frontier/env_vars.yaml
+++ b/frontier/env_vars.yaml
@@ -1,0 +1,6 @@
+env_vars:
+  set:
+    MPICH_GPU_SUPPORT_ENABLED: "1"
+    CFLAGS: -I/opt/cray/pe/mpich/8.1.31/ofi/crayclang/17.0/include -L/opt/cray/pe/mpich/8.1.31/ofi/crayclang/17.0/lib -lmpi -L/opt/cray/pe/mpich/8.1.31/gtl/lib -lmpi_gtl_hsa
+    CXXFLAGS: -I/opt/cray/pe/mpich/8.1.31/ofi/crayclang/17.0/include -L/opt/cray/pe/mpich/8.1.31/ofi/crayclang/17.0/lib -lmpi -L/opt/cray/pe/mpich/8.1.31/gtl/lib -lmpi_gtl_hsa
+    HIPFLAGS: -I/opt/cray/pe/mpich/8.1.31/ofi/crayclang/17.0/include -L/opt/cray/pe/mpich/8.1.31/ofi/crayclang/17.0/lib -lmpi -L/opt/cray/pe/mpich/8.1.31/gtl/lib -lmpi_gtl_hsa

--- a/frontier/environment.yaml
+++ b/frontier/environment.yaml
@@ -1,6 +1,6 @@
 environment:
   set:
-    MPICH_GPU_SUPPORT_ENABLED: 1
+    MPICH_GPU_SUPPORT_ENABLED: "1"
   append:
     CFLAGS: -I/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/include -L/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/lib -lmpi -L/opt/cray/pe/mpich/8.1.23/gtl/lib -lmpi_gtl_hsa
     CXXFLAGS: -I/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/include -L/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/lib -lmpi -L/opt/cray/pe/mpich/8.1.23/gtl/lib -lmpi_gtl_hsa

--- a/frontier/environment.yaml
+++ b/frontier/environment.yaml
@@ -1,7 +1,0 @@
-environment:
-  set:
-    MPICH_GPU_SUPPORT_ENABLED: "1"
-  append:
-    CFLAGS: -I/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/include -L/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/lib -lmpi -L/opt/cray/pe/mpich/8.1.23/gtl/lib -lmpi_gtl_hsa
-    CXXFLAGS: -I/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/include -L/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/lib -lmpi -L/opt/cray/pe/mpich/8.1.23/gtl/lib -lmpi_gtl_hsa
-    HIPFLAGS: -I/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/include -L/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/lib -lmpi -L/opt/cray/pe/mpich/8.1.23/gtl/lib -lmpi_gtl_hsa

--- a/frontier/rocm-5.3.0/packages.yaml
+++ b/frontier/rocm-5.3.0/packages.yaml
@@ -148,7 +148,7 @@ packages:
           hip: /opt/rocm-5.3.0/hip/bin/hipcc
         environment:
           set:
-            MPICH_GPU_SUPPORT_ENABLED: 1 
+            MPICH_GPU_SUPPORT_ENABLED: "1"
   llvm-amdgpu:
     buildable: false
     externals:

--- a/frontier/rocm-5.4.3/packages.yaml
+++ b/frontier/rocm-5.4.3/packages.yaml
@@ -148,7 +148,7 @@ packages:
           hip: /opt/rocm-5.4.3/hip/bin/hipcc
         environment:
           set:
-            MPICH_GPU_SUPPORT_ENABLED: 1 
+            MPICH_GPU_SUPPORT_ENABLED: "1"
     - spec: hip@5.4.3 %cce
       prefix: /opt/rocm-5.4.3
       modules:
@@ -161,7 +161,7 @@ packages:
           hip: /opt/rocm-5.4.3/hip/bin/hipcc
         environment:
           set:
-            MPICH_GPU_SUPPORT_ENABLED: 1 
+            MPICH_GPU_SUPPORT_ENABLED: "1"
     - spec: hip@5.4.3 %clang@15.0.0-rocm5.4.3
       prefix: /opt/rocm-5.4.3
       modules:
@@ -174,7 +174,7 @@ packages:
           hip: /opt/rocm-5.4.3/hip/bin/hipcc
         environment:
           set:
-            MPICH_GPU_SUPPORT_ENABLED: 1 
+            MPICH_GPU_SUPPORT_ENABLED: "1"
   llvm-amdgpu:
     buildable: false
     externals:

--- a/frontier/rocm-6.0.0/packages.yaml
+++ b/frontier/rocm-6.0.0/packages.yaml
@@ -148,7 +148,7 @@ packages:
           hip: /opt/rocm-6.0.0/hip/bin/hipcc
         environment:
           set:
-            MPICH_GPU_SUPPORT_ENABLED: 1 
+            MPICH_GPU_SUPPORT_ENABLED: "1"
   llvm-amdgpu:
     buildable: false
     externals:

--- a/frontier/rocm-6.2.0/packages.yaml
+++ b/frontier/rocm-6.2.0/packages.yaml
@@ -148,7 +148,7 @@ packages:
           hip: /opt/rocm-6.2.0/hip/bin/hipcc
         environment:
           set:
-            MPICH_GPU_SUPPORT_ENABLED: 1 
+            MPICH_GPU_SUPPORT_ENABLED: "1"
   llvm-amdgpu:
     buildable: false
     externals:

--- a/frontier/rocm-6.2.4/packages.yaml
+++ b/frontier/rocm-6.2.4/packages.yaml
@@ -148,7 +148,7 @@ packages:
           hip: /opt/rocm-6.2.4/hip/bin/hipcc
         environment:
           set:
-            MPICH_GPU_SUPPORT_ENABLED: 1 
+            MPICH_GPU_SUPPORT_ENABLED: "1"
   llvm-amdgpu:
     buildable: false
     externals:


### PR DESCRIPTION
This fixes some issues with setting environment on Frontier. These are all related to apparent changes in how Spack reads environment configuration from yaml files.