### PR TITLE
Frontier config update

### DIFF
--- a/crusher/packages.yaml
+++ b/crusher/packages.yaml
@@ -174,7 +174,7 @@ packages:
           hip: /opt/rocm-5.4.0/hip/bin/hipcc
       environment:
         set:
-          MPICH_GPU_SUPPORT_ENABLED: 1 
+          MPICH_GPU_SUPPORT_ENABLED: "1"
   llvm-amdgpu:
     buildable: false
     externals:

--- a/frontier/env_vars.yaml
+++ b/frontier/env_vars.yaml
@@ -1,0 +1,6 @@
+env_vars:
+  set:
+    MPICH_GPU_SUPPORT_ENABLED: "1"
+    CFLAGS: -I/opt/cray/pe/mpich/8.1.31/ofi/crayclang/17.0/include -L/opt/cray/pe/mpich/8.1.31/ofi/crayclang/17.0/lib -lmpi -L/opt/cray/pe/mpich/8.1.31/gtl/lib -lmpi_gtl_hsa
+    CXXFLAGS: -I/opt/cray/pe/mpich/8.1.31/ofi/crayclang/17.0/include -L/opt/cray/pe/mpich/8.1.31/ofi/crayclang/17.0/lib -lmpi -L/opt/cray/pe/mpich/8.1.31/gtl/lib -lmpi_gtl_hsa
+    HIPFLAGS: -I/opt/cray/pe/mpich/8.1.31/ofi/crayclang/17.0/include -L/opt/cray/pe/mpich/8.1.31/ofi/crayclang/17.0/lib -lmpi -L/opt/cray/pe/mpich/8.1.31/gtl/lib -lmpi_gtl_hsa

--- a/frontier/environment.yaml
+++ b/frontier/environment.yaml
@@ -1,6 +1,6 @@
 environment:
   set:
-    MPICH_GPU_SUPPORT_ENABLED: 1
+    MPICH_GPU_SUPPORT_ENABLED: "1"
   append:
     CFLAGS: -I/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/include -L/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/lib -lmpi -L/opt/cray/pe/mpich/8.1.23/gtl/lib -lmpi_gtl_hsa
     CXXFLAGS: -I/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/include -L/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/lib -lmpi -L/opt/cray/pe/mpich/8.1.23/gtl/lib -lmpi_gtl_hsa

--- a/frontier/environment.yaml
+++ b/frontier/environment.yaml
@@ -1,7 +1,0 @@
-environment:
-  set:
-    MPICH_GPU_SUPPORT_ENABLED: "1"
-  append:
-    CFLAGS: -I/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/include -L/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/lib -lmpi -L/opt/cray/pe/mpich/8.1.23/gtl/lib -lmpi_gtl_hsa
-    CXXFLAGS: -I/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/include -L/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/lib -lmpi -L/opt/cray/pe/mpich/8.1.23/gtl/lib -lmpi_gtl_hsa
-    HIPFLAGS: -I/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/include -L/opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0/lib -lmpi -L/opt/cray/pe/mpich/8.1.23/gtl/lib -lmpi_gtl_hsa

--- a/frontier/packages.yaml
+++ b/frontier/packages.yaml
@@ -25,6 +25,16 @@ packages:
           fortran: /usr/bin/gfortran-13
     - spec: gcc@14.2.0 languages:='c,c++,fortran'
       prefix: /usr
+      modules:
+        - gcc-native/14.2
+        - craype/2.7.35
+        - cray-dsmml/0.3.1
+        - cray-mpich/9.0.1
+        - cray-libsci/25.09.0
+        - craype-x86-trento
+        - cray-pmi/6.1.16
+        - libfabric/1.22.0
+        - xpmem/2.10.6-1.2_gfaa90a94be64
       extra_attributes:
         compilers:
           c: /usr/bin/gcc-14

--- a/frontier/packages.yaml
+++ b/frontier/packages.yaml
@@ -33,7 +33,7 @@ packages:
         - cray-libsci/25.09.0
         - craype-x86-trento
         - cray-pmi/6.1.16
-        - libfabric/1.22.0
+        - libfabric/1.20.1
         - xpmem/2.10.6-1.2_gfaa90a94be64
       extra_attributes:
         compilers:
@@ -66,33 +66,33 @@ packages:
     - spec: cray-mpich@8.1.31
       modules:
       - cray-mpich/8.1.31
-      - libfabric/1.22.0
+      - libfabric/1.20.1
     # - spec: cray-mpich@8.1.23 %gcc
     #   prefix: /opt/cray/pe/mpich/8.1.23/ofi/gnu/9.1
     #   modules:
     #   - cray-mpich/8.1.23
-    #   - libfabric/1.22.0
+    #   - libfabric/1.20.1
     # - spec: cray-mpich@8.1.23 %cce
     #   prefix: /opt/cray/pe/mpich/8.1.23/ofi/crayclang/10.0
     #   modules:
     #   - cray-mpich/8.1.23
-    #   - libfabric/1.22.0
+    #   - libfabric/1.20.1
     # - spec: cray-mpich@8.1.17 %clang@15.0.0-rocm5.3.0
     #   prefix: /opt/cray/pe/mpich/8.1.23/ofi/amd/5.0
     #   modules:
     #   - cray-mpich/8.1.23
-    #   - libfabric/1.22.0
+    #   - libfabric/1.20.1
     # - spec: cray-mpich@8.1.17 %clang@15.0.0-rocm5.4.3
     #   prefix: /opt/cray/pe/mpich/8.1.23/ofi/amd/5.0
     #   modules:
     #   - cray-mpich/8.1.23
-    #   - libfabric/1.22.0
+    #   - libfabric/1.20.1
   libfabric:
     buildable: false
     externals:
-    - spec: libfabric@1.22.0
+    - spec: libfabric@1.20.1
       modules:
-      - libfabric/1.22.0
+      - libfabric/1.20.1
   # libffi:
   #   # py-cffi requires libffi.so.8 which is not on this system
   #   buildable: false

--- a/frontier/rocm-5.3.0/packages.yaml
+++ b/frontier/rocm-5.3.0/packages.yaml
@@ -148,7 +148,7 @@ packages:
           hip: /opt/rocm-5.3.0/hip/bin/hipcc
         environment:
           set:
-            MPICH_GPU_SUPPORT_ENABLED: 1 
+            MPICH_GPU_SUPPORT_ENABLED: "1"
   llvm-amdgpu:
     buildable: false
     externals:

--- a/frontier/rocm-5.4.3/packages.yaml
+++ b/frontier/rocm-5.4.3/packages.yaml
@@ -148,7 +148,7 @@ packages:
           hip: /opt/rocm-5.4.3/hip/bin/hipcc
         environment:
           set:
-            MPICH_GPU_SUPPORT_ENABLED: 1 
+            MPICH_GPU_SUPPORT_ENABLED: "1"
     - spec: hip@5.4.3 %cce
       prefix: /opt/rocm-5.4.3
       modules:
@@ -161,7 +161,7 @@ packages:
           hip: /opt/rocm-5.4.3/hip/bin/hipcc
         environment:
           set:
-            MPICH_GPU_SUPPORT_ENABLED: 1 
+            MPICH_GPU_SUPPORT_ENABLED: "1"
     - spec: hip@5.4.3 %clang@15.0.0-rocm5.4.3
       prefix: /opt/rocm-5.4.3
       modules:
@@ -174,7 +174,7 @@ packages:
           hip: /opt/rocm-5.4.3/hip/bin/hipcc
         environment:
           set:
-            MPICH_GPU_SUPPORT_ENABLED: 1 
+            MPICH_GPU_SUPPORT_ENABLED: "1"
   llvm-amdgpu:
     buildable: false
     externals:

--- a/frontier/rocm-6.0.0/packages.yaml
+++ b/frontier/rocm-6.0.0/packages.yaml
@@ -148,7 +148,7 @@ packages:
           hip: /opt/rocm-6.0.0/hip/bin/hipcc
         environment:
           set:
-            MPICH_GPU_SUPPORT_ENABLED: 1 
+            MPICH_GPU_SUPPORT_ENABLED: "1"
   llvm-amdgpu:
     buildable: false
     externals:

--- a/frontier/rocm-6.2.0/packages.yaml
+++ b/frontier/rocm-6.2.0/packages.yaml
@@ -148,7 +148,7 @@ packages:
           hip: /opt/rocm-6.2.0/hip/bin/hipcc
         environment:
           set:
-            MPICH_GPU_SUPPORT_ENABLED: 1 
+            MPICH_GPU_SUPPORT_ENABLED: "1"
   llvm-amdgpu:
     buildable: false
     externals:

--- a/frontier/rocm-6.2.4/packages.yaml
+++ b/frontier/rocm-6.2.4/packages.yaml
@@ -148,7 +148,7 @@ packages:
           hip: /opt/rocm-6.2.4/hip/bin/hipcc
         environment:
           set:
-            MPICH_GPU_SUPPORT_ENABLED: 1 
+            MPICH_GPU_SUPPORT_ENABLED: "1"
   llvm-amdgpu:
     buildable: false
     externals:

--- a/frontier/rocm-6.2.4/packages.yaml
+++ b/frontier/rocm-6.2.4/packages.yaml
@@ -156,6 +156,16 @@ packages:
       prefix: /opt/rocm-6.2.4/llvm
       modules:
       - rocm/6.2.4
+      - craype/2.7.35
+      - cray-dsmml/0.3.1
+      - cray-mpich/9.0.1
+      - cray-libsci/25.09.0
+      - amd/6.4.2
+      - PrgEnv-amd
+      - craype-x86-trento
+      - cray-pmi/6.1.16
+      - libfabric/1.22.0
+      - xpmem/2.10.6-1.2_gfaa90a94be64
       extra_attributes:
         compilers:
           c: /opt/rocm-6.2.4/llvm/bin/clang


### PR DESCRIPTION
Contains multiple updates for spack configuration of Frontier for both changes in Spack and changes in the Frontier stack.

* Ensure that environment variables are defined as strings. (Spack got more picky about numeric environment variables.)
* Update the modules loaded for the GCC compiler to properly load the GTL libraries
* Update the version for the libfabric module (which changed from 1.22.0 to 1.20.1